### PR TITLE
[codex] Add expanded navigation bar API

### DIFF
--- a/.github/scripts/verify-packed-example.sh
+++ b/.github/scripts/verify-packed-example.sh
@@ -38,16 +38,23 @@ bun remove "$plugin_name"
 bun add "${packed_packages[0]}"
 bun run build
 
+ensure_platform() {
+  local platform="$1"
+  if [ -d "$platform" ]; then
+    bunx cap sync "$platform"
+  else
+    bunx cap add "$platform"
+  fi
+}
+
 case "$platform" in
   android)
-    bunx cap add android
-    bunx cap sync android
+    ensure_platform android
     cd android
     ./gradlew build test
     ;;
   ios)
-    bunx cap add ios
-    bunx cap sync ios
+    ensure_platform ios
     xcodebuild -project ios/App/App.xcodeproj -scheme App -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO
     ;;
   web)

--- a/README.md
+++ b/README.md
@@ -40,9 +40,16 @@ npx cap sync
 
 <docgen-index>
 
+* [`getColor()`](#getcolor)
+* [`getStyle()`](#getstyle)
+* [`hide()`](#hide)
+* [`setColor(...)`](#setcolor)
+* [`setStyle(...)`](#setstyle)
+* [`show()`](#show)
 * [`setNavigationBarColor(...)`](#setnavigationbarcolor)
 * [`getNavigationBarColor()`](#getnavigationbarcolor)
 * [`getPluginVersion()`](#getpluginversion)
+* [Interfaces](#interfaces)
 * [Enums](#enums)
 
 </docgen-index>
@@ -51,6 +58,108 @@ npx cap sync
 <!--Update the source file JSDoc comments and rerun docgen to update the docs below-->
 
 Capacitor Navigation Bar Plugin for customizing the Android navigation bar.
+
+### getColor()
+
+```typescript
+getColor() => Promise<GetColorResult>
+```
+
+Get the current background color of the navigation bar.
+
+Only available on Android.
+
+**Returns:** <code>Promise&lt;<a href="#getcolorresult">GetColorResult</a>&gt;</code>
+
+**Since:** 8.2.0
+
+--------------------
+
+
+### getStyle()
+
+```typescript
+getStyle() => Promise<GetStyleResult>
+```
+
+Get the current style of the navigation bar buttons.
+
+Only available on Android.
+
+**Returns:** <code>Promise&lt;<a href="#getstyleresult">GetStyleResult</a>&gt;</code>
+
+**Since:** 8.2.0
+
+--------------------
+
+
+### hide()
+
+```typescript
+hide() => Promise<void>
+```
+
+Hide the navigation bar.
+
+Only available on Android.
+
+**Since:** 8.2.0
+
+--------------------
+
+
+### setColor(...)
+
+```typescript
+setColor(options: SetColorOptions) => Promise<void>
+```
+
+Set the background color of the navigation bar.
+
+Only available on Android.
+
+| Param         | Type                                                        |
+| ------------- | ----------------------------------------------------------- |
+| **`options`** | <code><a href="#setcoloroptions">SetColorOptions</a></code> |
+
+**Since:** 8.2.0
+
+--------------------
+
+
+### setStyle(...)
+
+```typescript
+setStyle(options: SetStyleOptions) => Promise<void>
+```
+
+Set the style of the navigation bar buttons.
+
+Only available on Android.
+
+| Param         | Type                                                        |
+| ------------- | ----------------------------------------------------------- |
+| **`options`** | <code><a href="#setstyleoptions">SetStyleOptions</a></code> |
+
+**Since:** 8.2.0
+
+--------------------
+
+
+### show()
+
+```typescript
+show() => Promise<void>
+```
+
+Show the navigation bar.
+
+Only available on Android.
+
+**Since:** 8.2.0
+
+--------------------
+
 
 ### setNavigationBarColor(...)
 
@@ -99,7 +208,48 @@ Get the native Capacitor plugin version.
 --------------------
 
 
+### Interfaces
+
+
+#### GetColorResult
+
+| Prop        | Type                | Description                                                                                                 | Since |
+| ----------- | ------------------- | ----------------------------------------------------------------------------------------------------------- | ----- |
+| **`color`** | <code>string</code> | The hexadecimal color of the navigation bar, or `'transparent'` if the navigation bar is fully transparent. | 8.2.0 |
+
+
+#### GetStyleResult
+
+| Prop        | Type                                    | Description                              | Since |
+| ----------- | --------------------------------------- | ---------------------------------------- | ----- |
+| **`style`** | <code><a href="#style">Style</a></code> | The style of the navigation bar buttons. | 8.2.0 |
+
+
+#### SetColorOptions
+
+| Prop               | Type                | Description                                                                                                                                                  | Since |
+| ------------------ | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----- |
+| **`color`**        | <code>string</code> | The hexadecimal color to set as the background color of the navigation bar. Use `'transparent'` to make the navigation bar transparent.                      | 8.2.0 |
+| **`dividerColor`** | <code>string</code> | The hexadecimal color to set as the color of the navigation bar divider. Use `'transparent'` to hide the divider. Only available on Android (API level 28+). | 8.2.0 |
+
+
+#### SetStyleOptions
+
+| Prop        | Type                                    | Description                              | Since |
+| ----------- | --------------------------------------- | ---------------------------------------- | ----- |
+| **`style`** | <code><a href="#style">Style</a></code> | The style of the navigation bar buttons. | 8.2.0 |
+
+
 ### Enums
+
+
+#### Style
+
+| Members       | Value                  | Description                                  | Since |
+| ------------- | ---------------------- | -------------------------------------------- | ----- |
+| **`Dark`**    | <code>'DARK'</code>    | Light icons on a dark background.            | 8.2.0 |
+| **`Default`** | <code>'DEFAULT'</code> | Resolved from the current device appearance. | 8.2.0 |
+| **`Light`**   | <code>'LIGHT'</code>   | Dark icons on a light background.            | 8.2.0 |
 
 
 #### NavigationBarColor

--- a/android/src/main/java/ee/forgr/capacitor_navigation_bar/CapgoNavigationBarPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_navigation_bar/CapgoNavigationBarPlugin.java
@@ -1,10 +1,14 @@
 package ee.forgr.capacitor_navigation_bar;
 
+import android.content.res.Configuration;
 import android.graphics.Color;
 import android.os.Build;
 import android.view.View;
+import android.view.Window;
+import android.view.WindowInsets;
 import android.view.WindowInsetsController;
 import com.getcapacitor.JSObject;
+import com.getcapacitor.Logger;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
@@ -15,7 +19,133 @@ import java.util.Locale;
 @CapacitorPlugin(name = "NavigationBar")
 public class CapgoNavigationBarPlugin extends Plugin {
 
+    private static final String ERROR_COLOR_MISSING = "color must be provided.";
+    private static final String ERROR_STYLE_MISSING = "style must be provided.";
+    private static final String ERROR_STYLE_INVALID = "style must be DARK, LIGHT, or DEFAULT.";
+    private static final String STYLE_DARK = "DARK";
+    private static final String STYLE_DEFAULT = "DEFAULT";
+    private static final String STYLE_LIGHT = "LIGHT";
+    private static final String TAG = "NavigationBar";
+    private static final String TRANSPARENT = "transparent";
+
     private final String pluginVersion = "8.1.8";
+
+    @Override
+    public void load() {
+        final String color = getConfig().getString("color");
+        final String dividerColor = getConfig().getString("dividerColor");
+        final String style = getConfig().getString("style");
+
+        if (color == null && style == null) {
+            return;
+        }
+
+        getBridge().executeOnMainThread(() -> {
+            try {
+                if (color != null) {
+                    applyColor(color, dividerColor);
+                }
+                if (style != null) {
+                    applyStyle(style);
+                }
+            } catch (Exception ex) {
+                Logger.error(TAG, "Failed to apply NavigationBar config", ex);
+            }
+        });
+    }
+
+    @PluginMethod
+    public void getColor(PluginCall call) {
+        getBridge().executeOnMainThread(() -> {
+            JSObject ret = new JSObject();
+            ret.put("color", getFormattedNavigationBarColor());
+            call.resolve(ret);
+        });
+    }
+
+    @PluginMethod
+    public void getStyle(PluginCall call) {
+        getBridge().executeOnMainThread(() -> {
+            JSObject ret = new JSObject();
+            ret.put("style", areDarkButtonsEnabled() ? STYLE_LIGHT : STYLE_DARK);
+            call.resolve(ret);
+        });
+    }
+
+    @PluginMethod
+    public void hide(PluginCall call) {
+        getBridge().executeOnMainThread(() -> {
+            Window window = getActivity().getWindow();
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                WindowInsetsController insetsController = window.getInsetsController();
+                if (insetsController != null) {
+                    insetsController.hide(WindowInsets.Type.navigationBars());
+                }
+            } else {
+                int flags = window.getDecorView().getSystemUiVisibility();
+                flags |= View.SYSTEM_UI_FLAG_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY;
+                window.getDecorView().setSystemUiVisibility(flags);
+            }
+            call.resolve();
+        });
+    }
+
+    @PluginMethod
+    public void setColor(PluginCall call) {
+        final String color = call.getString("color");
+        final String dividerColor = call.getString("dividerColor");
+
+        if (color == null) {
+            call.reject(ERROR_COLOR_MISSING);
+            return;
+        }
+
+        getBridge().executeOnMainThread(() -> {
+            try {
+                applyColor(color, dividerColor);
+                call.resolve();
+            } catch (IllegalArgumentException ex) {
+                call.reject("Invalid color provided. color and dividerColor must be hex colors (#RRGGBB) or 'transparent'.");
+            }
+        });
+    }
+
+    @PluginMethod
+    public void setStyle(PluginCall call) {
+        final String style = call.getString("style");
+
+        if (style == null) {
+            call.reject(ERROR_STYLE_MISSING);
+            return;
+        }
+
+        getBridge().executeOnMainThread(() -> {
+            try {
+                applyStyle(style);
+                call.resolve();
+            } catch (IllegalArgumentException ex) {
+                call.reject(ex.getMessage());
+            }
+        });
+    }
+
+    @PluginMethod
+    public void show(PluginCall call) {
+        getBridge().executeOnMainThread(() -> {
+            Window window = getActivity().getWindow();
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                WindowInsetsController insetsController = window.getInsetsController();
+                if (insetsController != null) {
+                    insetsController.show(WindowInsets.Type.navigationBars());
+                }
+            } else {
+                int flags = window.getDecorView().getSystemUiVisibility();
+                flags &= ~View.SYSTEM_UI_FLAG_HIDE_NAVIGATION & ~View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY;
+                window.getDecorView().setSystemUiVisibility(flags);
+            }
+            call.resolve();
+        });
+    }
 
     @PluginMethod
     public void setNavigationBarColor(PluginCall call) {
@@ -30,55 +160,11 @@ public class CapgoNavigationBarPlugin extends Plugin {
 
         getBridge().executeOnMainThread(() -> {
             try {
-                final Integer parsedDividerColor =
-                    Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && dividerColor != null
-                        ? ("transparent".equalsIgnoreCase(dividerColor) ? Color.TRANSPARENT : WebColor.parseColor(dividerColor))
-                        : null;
-
-                if ("transparent".equalsIgnoreCase(color)) {
-                    int flags = getActivity().getWindow().getDecorView().getSystemUiVisibility();
-                    flags |= View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_LAYOUT_STABLE;
-                    getActivity().getWindow().getDecorView().setSystemUiVisibility(flags);
-                    getActivity().getWindow().setNavigationBarColor(Color.TRANSPARENT);
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && parsedDividerColor != null) {
-                        getActivity().getWindow().setNavigationBarDividerColor(parsedDividerColor);
-                    }
-                } else {
-                    final int parsedColor = WebColor.parseColor(color);
-                    View decor = getActivity().getWindow().getDecorView();
-                    int flags = decor.getSystemUiVisibility();
-                    flags &= ~View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION & ~View.SYSTEM_UI_FLAG_LAYOUT_STABLE;
-                    decor.setSystemUiVisibility(flags);
-                    getActivity().getWindow().setNavigationBarColor(parsedColor);
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && parsedDividerColor != null) {
-                        getActivity().getWindow().setNavigationBarDividerColor(parsedDividerColor);
-                    }
-                }
-
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                    WindowInsetsController insetsController = getActivity().getWindow().getInsetsController();
-                    if (insetsController != null) {
-                        if (darkButtons) {
-                            insetsController.setSystemBarsAppearance(
-                                WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS,
-                                WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS
-                            );
-                        } else {
-                            insetsController.setSystemBarsAppearance(0, WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS);
-                        }
-                    }
-                } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    int flags = getActivity().getWindow().getDecorView().getSystemUiVisibility();
-                    if (darkButtons) {
-                        flags |= View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR;
-                    } else {
-                        flags &= ~View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR;
-                    }
-                    getActivity().getWindow().getDecorView().setSystemUiVisibility(flags);
-                }
+                applyColor(color, dividerColor);
+                applyDarkButtons(darkButtons);
                 call.resolve();
             } catch (IllegalArgumentException ex) {
-                call.reject("Invalid color provided. color and dividerColor must be hex colors (#RRGGBB) or color can be 'transparent'");
+                call.reject("Invalid color provided. color and dividerColor must be hex colors (#RRGGBB) or 'transparent'.");
             }
         });
     }
@@ -88,27 +174,8 @@ public class CapgoNavigationBarPlugin extends Plugin {
         getBridge().executeOnMainThread(() -> {
             try {
                 JSObject ret = new JSObject();
-                int intColor = getActivity().getWindow().getNavigationBarColor();
-                String hexColor = String.format("#%06X", (0xFFFFFF & intColor));
-                ret.put("color", hexColor);
-
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                    WindowInsetsController insetsController = getActivity().getWindow().getInsetsController();
-                    if (insetsController != null) {
-                        int appearance = insetsController.getSystemBarsAppearance();
-                        boolean isLight = (appearance & WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS) != 0;
-                        ret.put("darkButtons", !isLight);
-                    } else {
-                        ret.put("darkButtons", true);
-                    }
-                } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    int flags = getActivity().getWindow().getDecorView().getSystemUiVisibility();
-                    boolean isLight = (flags & View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR) != 0;
-                    ret.put("darkButtons", !isLight);
-                } else {
-                    ret.put("darkButtons", true);
-                }
-
+                ret.put("color", getFormattedNavigationBarColor());
+                ret.put("darkButtons", areDarkButtonsEnabled());
                 call.resolve(ret);
             } catch (Exception ex) {
                 call.reject("Failed to get navigation bar color or button style", ex);
@@ -125,5 +192,105 @@ public class CapgoNavigationBarPlugin extends Plugin {
         } catch (final Exception e) {
             call.reject("Could not get plugin version", e);
         }
+    }
+
+    private void applyColor(String color, String dividerColor) {
+        final Window window = getActivity().getWindow();
+        final Integer parsedDividerColor =
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && dividerColor != null ? parseColor(dividerColor) : null;
+
+        if (TRANSPARENT.equalsIgnoreCase(color)) {
+            setTransparentLayoutEnabled(window, true);
+            window.setNavigationBarColor(Color.TRANSPARENT);
+        } else {
+            setTransparentLayoutEnabled(window, false);
+            window.setNavigationBarColor(parseColor(color));
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && parsedDividerColor != null) {
+            window.setNavigationBarDividerColor(parsedDividerColor);
+        }
+    }
+
+    private void applyStyle(String style) {
+        final String resolvedStyle = resolveStyle(style);
+        applyDarkButtons(STYLE_LIGHT.equals(resolvedStyle));
+    }
+
+    private void applyDarkButtons(boolean darkButtons) {
+        final Window window = getActivity().getWindow();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            WindowInsetsController insetsController = window.getInsetsController();
+            if (insetsController != null) {
+                insetsController.setSystemBarsAppearance(
+                    darkButtons ? WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS : 0,
+                    WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS
+                );
+            }
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            int flags = window.getDecorView().getSystemUiVisibility();
+            if (darkButtons) {
+                flags |= View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR;
+            } else {
+                flags &= ~View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR;
+            }
+            window.getDecorView().setSystemUiVisibility(flags);
+        }
+    }
+
+    private boolean areDarkButtonsEnabled() {
+        final Window window = getActivity().getWindow();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            WindowInsetsController insetsController = window.getInsetsController();
+            if (insetsController != null) {
+                int appearance = insetsController.getSystemBarsAppearance();
+                return (appearance & WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS) != 0;
+            }
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            int flags = window.getDecorView().getSystemUiVisibility();
+            return (flags & View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR) != 0;
+        }
+        return false;
+    }
+
+    private String getFormattedNavigationBarColor() {
+        int intColor = getActivity().getWindow().getNavigationBarColor();
+        if (Color.alpha(intColor) == 0) {
+            return TRANSPARENT;
+        }
+        return String.format("#%06X", (0xFFFFFF & intColor));
+    }
+
+    private boolean isNightMode() {
+        int nightModeFlags = getContext().getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
+        return nightModeFlags == Configuration.UI_MODE_NIGHT_YES;
+    }
+
+    private int parseColor(String color) {
+        if (TRANSPARENT.equalsIgnoreCase(color)) {
+            return Color.TRANSPARENT;
+        }
+        return WebColor.parseColor(color);
+    }
+
+    private String resolveStyle(String style) {
+        final String normalizedStyle = style.toUpperCase(Locale.ROOT);
+        if (STYLE_DEFAULT.equals(normalizedStyle)) {
+            return isNightMode() ? STYLE_DARK : STYLE_LIGHT;
+        }
+        if (STYLE_DARK.equals(normalizedStyle) || STYLE_LIGHT.equals(normalizedStyle)) {
+            return normalizedStyle;
+        }
+        throw new IllegalArgumentException(ERROR_STYLE_INVALID);
+    }
+
+    private void setTransparentLayoutEnabled(Window window, boolean enabled) {
+        int flags = window.getDecorView().getSystemUiVisibility();
+        if (enabled) {
+            flags |= View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION | View.SYSTEM_UI_FLAG_LAYOUT_STABLE;
+        } else {
+            flags &= ~View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION & ~View.SYSTEM_UI_FLAG_LAYOUT_STABLE;
+        }
+        window.getDecorView().setSystemUiVisibility(flags);
     }
 }

--- a/ios/Sources/CapgoNavigationBarPlugin/CapgoNavigationBarPlugin.swift
+++ b/ios/Sources/CapgoNavigationBarPlugin/CapgoNavigationBarPlugin.swift
@@ -11,15 +11,47 @@ public class CapgoNavigationBarPlugin: CAPPlugin, CAPBridgedPlugin {
     public let identifier = "CapgoNavigationBarPlugin"
     public let jsName = "NavigationBar"
     public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "getColor", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getStyle", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "hide", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "setColor", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "setStyle", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "show", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setNavigationBarColor", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getNavigationBarColor", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getPluginVersion", returnType: CAPPluginReturnPromise)
     ]
+
+    @objc func getColor(_ call: CAPPluginCall) {
+        rejectUnsupported(call)
+    }
+
+    @objc func getStyle(_ call: CAPPluginCall) {
+        rejectUnsupported(call)
+    }
+
+    @objc func hide(_ call: CAPPluginCall) {
+        rejectUnsupported(call)
+    }
+
+    @objc func setColor(_ call: CAPPluginCall) {
+        rejectUnsupported(call)
+    }
+
+    @objc func setStyle(_ call: CAPPluginCall) {
+        rejectUnsupported(call)
+    }
+
+    @objc func show(_ call: CAPPluginCall) {
+        rejectUnsupported(call)
+    }
+
     @objc func setNavigationBarColor(_ call: CAPPluginCall) {
         let color = call.getString("color") ?? ""
         print("Cannot set navigation bar color in ios \(color)")
         call.reject("Cannot set navigation bar color in ios")
     }
+
     @objc func getNavigationBarColor(_ call: CAPPluginCall) {
         print("Cannot get navigation bar color in ios")
         call.reject("Cannot get navigation bar color in ios")
@@ -27,6 +59,10 @@ public class CapgoNavigationBarPlugin: CAPPlugin, CAPBridgedPlugin {
 
     @objc func getPluginVersion(_ call: CAPPluginCall) {
         call.resolve(["version": self.pluginVersion])
+    }
+
+    private func rejectUnsupported(_ call: CAPPluginCall) {
+        call.reject("Navigation bar is only available on Android")
     }
 
 }

--- a/package.json
+++ b/package.json
@@ -34,20 +34,20 @@
     "native"
   ],
   "scripts": {
-    "verify": "npm run verify:ios && npm run verify:android && npm run verify:web",
+    "verify": "bun run verify:ios && bun run verify:android && bun run verify:web",
     "verify:ios": "xcodebuild -scheme CapgoCapacitorNavigationBar -destination generic/platform=iOS",
     "verify:android": "cd android && ./gradlew clean build test && cd ..",
-    "verify:web": "npm run build",
-    "lint": "npm run eslint && npm run prettier -- --check && npm run swiftlint -- lint",
-    "fmt": "npm run eslint -- --fix && npm run prettier -- --write && npm run swiftlint -- --fix --format",
+    "verify:web": "bun run build",
+    "lint": "bun run eslint && bun run prettier -- --check && bun run swiftlint -- lint",
+    "fmt": "bun run eslint -- --fix && bun run prettier -- --write && bun run swiftlint -- --fix --format",
     "eslint": "eslint .",
     "prettier": "prettier-pretty-check \"**/*.{css,html,ts,js,java}\" --plugin=prettier-plugin-java",
     "swiftlint": "node-swiftlint",
     "docgen": "docgen --api NavigationBarPlugin --output-readme README.md --output-json dist/docs.json",
-    "build": "npm run clean && npm run docgen && tsc && rollup -c rollup.config.mjs",
+    "build": "bun run clean && bun run docgen && tsc && rollup -c rollup.config.mjs",
     "clean": "rimraf ./dist",
     "watch": "tsc --watch",
-    "prepublishOnly": "npm run build",
+    "prepublishOnly": "bun run build",
     "check:wiring": "node scripts/check-capacitor-plugin-wiring.mjs"
   },
   "devDependencies": {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,3 +1,43 @@
+/// <reference types="@capacitor/cli" />
+
+declare module '@capacitor/cli' {
+  export interface PluginsConfig {
+    NavigationBar?: {
+      /**
+       * The hexadecimal color to set as the background color of the navigation bar.
+       *
+       * Use `'transparent'` to make the navigation bar transparent.
+       *
+       * Only available on Android.
+       *
+       * @since 8.2.0
+       * @example "#ffffff"
+       */
+      color?: string;
+      /**
+       * The hexadecimal color to set as the color of the navigation bar divider.
+       *
+       * Use `'transparent'` to hide the divider.
+       *
+       * Only available on Android (API level 28+).
+       *
+       * @since 8.2.0
+       * @example "#d9d9d9"
+       */
+      dividerColor?: string;
+      /**
+       * The style of the navigation bar buttons.
+       *
+       * Only available on Android.
+       *
+       * @since 8.2.0
+       * @example "LIGHT"
+       */
+      style?: 'DARK' | 'LIGHT' | 'DEFAULT';
+    };
+  }
+}
+
 /**
  * Predefined navigation bar colors.
  *
@@ -13,11 +53,184 @@ export enum NavigationBarColor {
 }
 
 /**
+ * Navigation bar button style.
+ *
+ * @since 8.2.0
+ */
+export enum Style {
+  /**
+   * Light icons on a dark background.
+   *
+   * @since 8.2.0
+   */
+  Dark = 'DARK',
+  /**
+   * Resolved from the current device appearance.
+   *
+   * @since 8.2.0
+   */
+  Default = 'DEFAULT',
+  /**
+   * Dark icons on a light background.
+   *
+   * @since 8.2.0
+   */
+  Light = 'LIGHT',
+}
+
+/**
+ * @since 8.2.0
+ */
+export interface GetColorResult {
+  /**
+   * The hexadecimal color of the navigation bar, or `'transparent'` if the navigation bar is fully transparent.
+   *
+   * @since 8.2.0
+   * @example "#ffffff"
+   * @example "transparent"
+   */
+  color: string;
+}
+
+/**
+ * @since 8.2.0
+ */
+export interface GetStyleResult {
+  /**
+   * The style of the navigation bar buttons.
+   *
+   * @since 8.2.0
+   */
+  style: Style;
+}
+
+/**
+ * @since 8.2.0
+ */
+export interface SetColorOptions {
+  /**
+   * The hexadecimal color to set as the background color of the navigation bar.
+   *
+   * Use `'transparent'` to make the navigation bar transparent.
+   *
+   * @since 8.2.0
+   * @example "#ffffff"
+   */
+  color: NavigationBarColor | string;
+  /**
+   * The hexadecimal color to set as the color of the navigation bar divider.
+   *
+   * Use `'transparent'` to hide the divider.
+   *
+   * Only available on Android (API level 28+).
+   *
+   * @since 8.2.0
+   * @example "#d9d9d9"
+   */
+  dividerColor?: NavigationBarColor | string;
+}
+
+/**
+ * @since 8.2.0
+ */
+export interface SetStyleOptions {
+  /**
+   * The style of the navigation bar buttons.
+   *
+   * @since 8.2.0
+   */
+  style: Style;
+}
+
+/**
  * Capacitor Navigation Bar Plugin for customizing the Android navigation bar.
  *
  * @since 1.0.0
  */
 export interface NavigationBarPlugin {
+  /**
+   * Get the current background color of the navigation bar.
+   *
+   * Only available on Android.
+   *
+   * @since 8.2.0
+   * @example
+   * ```typescript
+   * const { color } = await NavigationBar.getColor();
+   * console.log('Current color:', color);
+   * ```
+   */
+  getColor(): Promise<GetColorResult>;
+
+  /**
+   * Get the current style of the navigation bar buttons.
+   *
+   * Only available on Android.
+   *
+   * @since 8.2.0
+   * @example
+   * ```typescript
+   * const { style } = await NavigationBar.getStyle();
+   * console.log('Current style:', style);
+   * ```
+   */
+  getStyle(): Promise<GetStyleResult>;
+
+  /**
+   * Hide the navigation bar.
+   *
+   * Only available on Android.
+   *
+   * @since 8.2.0
+   * @example
+   * ```typescript
+   * await NavigationBar.hide();
+   * ```
+   */
+  hide(): Promise<void>;
+
+  /**
+   * Set the background color of the navigation bar.
+   *
+   * Only available on Android.
+   *
+   * @since 8.2.0
+   * @example
+   * ```typescript
+   * await NavigationBar.setColor({
+   *   color: '#ffffff',
+   *   dividerColor: '#d9d9d9',
+   * });
+   * ```
+   */
+  setColor(options: SetColorOptions): Promise<void>;
+
+  /**
+   * Set the style of the navigation bar buttons.
+   *
+   * Only available on Android.
+   *
+   * @since 8.2.0
+   * @example
+   * ```typescript
+   * await NavigationBar.setStyle({ style: Style.Light });
+   * ```
+   */
+  setStyle(options: SetStyleOptions): Promise<void>;
+
+  /**
+   * Show the navigation bar.
+   *
+   * Only available on Android.
+   *
+   * @since 8.2.0
+   * @example
+   * ```typescript
+   * await NavigationBar.show();
+   * ```
+   */
+  show(): Promise<void>;
+
   /**
    * Set the navigation bar color and button theme.
    *

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,12 +1,39 @@
 import { WebPlugin } from '@capacitor/core';
 
-import type { NavigationBarPlugin } from './definitions';
+import type { NavigationBarPlugin, SetColorOptions, SetStyleOptions } from './definitions';
+import { Style } from './definitions';
 
 export class NavigationBarWeb extends WebPlugin implements NavigationBarPlugin {
+  async getColor(): Promise<{ color: string }> {
+    console.log('Cannot getColor on web');
+    return { color: '#000000' };
+  }
+
+  async getStyle(): Promise<{ style: Style }> {
+    console.log('Cannot getStyle on web');
+    return { style: Style.Light };
+  }
+
+  async hide(): Promise<void> {
+    console.log('Cannot hide navigation bar on web');
+  }
+
+  async setColor(options: SetColorOptions): Promise<void> {
+    console.log('Cannot setColor on web', options);
+  }
+
+  async setStyle(options: SetStyleOptions): Promise<void> {
+    console.log('Cannot setStyle on web', options);
+  }
+
+  async show(): Promise<void> {
+    console.log('Cannot show navigation bar on web');
+  }
+
   async setNavigationBarColor(options: { color: string; darkButtons?: boolean; dividerColor?: string }): Promise<void> {
     console.log('Cannot setNavigationBarColor on web', options);
-    return;
   }
+
   async getNavigationBarColor(): Promise<{
     color: string;
     darkButtons: boolean;


### PR DESCRIPTION
## What
- Add expanded NavigationBar APIs: `getColor`, `getStyle`, `hide`, `setColor`, `setStyle`, and `show`.
- Add typed Capacitor config support for `color`, `dividerColor`, and `style`.
- Keep the existing Capgo `setNavigationBarColor`, `getNavigationBarColor`, and `getPluginVersion` APIs for compatibility.
- Regenerate README API docs, align package script chaining with Bun, and make the packed-example verifier sync existing native projects instead of re-adding them.

## Why
- The plugin was missing separated color/style APIs, navigation bar visibility control, and config-time application.
- CI packed-example checks copied native projects that already contain `android/` and `ios/`, so `cap add` failed before native package verification could run.

## How
- Expanded `src/definitions.ts` as the docgen source of truth and added web stubs.
- Updated Android native code to apply config on load, support the new method names, resolve `Style.Default` from current night mode, support `transparent` color/divider values, and use platform navigation bar hide/show APIs.
- Registered the new iOS methods as Android-only rejections while preserving the old iOS method behavior.
- Updated `.github/scripts/verify-packed-example.sh` to `cap sync` when copied example native platforms already exist.

## Testing
- `bun run fmt`
- `JAVA_HOME=/opt/homebrew/Cellar/openjdk@21/21.0.11 ANDROID_HOME=$HOME/Library/Android/sdk bun run verify`
- `bun run lint`
- `bun run check:wiring`
- `RUNNER_TEMP=/tmp/capgo-nav-packed-test JAVA_HOME=/opt/homebrew/Cellar/openjdk@21/21.0.11 ANDROID_HOME=$HOME/Library/Android/sdk bash ./.github/scripts/verify-packed-example.sh android`
- `RUNNER_TEMP=/tmp/capgo-nav-packed-test-ios bash ./.github/scripts/verify-packed-example.sh ios`

## Not Tested
- Runtime behavior on a physical Android device with 3-button navigation and gesture navigation modes.